### PR TITLE
Update config to get oauth backend working

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,19 @@ To get started clone the repo and run
 
 ``` bash
 $ npm install
-$ npm start
+$ npm run start:local
 ```
 (`npm install` might error about Snyk if it’s not set up but ignore for now)
 
-Then go to [http://localhost:3000/](http://localhost:3000/) to see it in action.
+Then go to [http://localhost:3000/individual-id/1](http://localhost:3000/individual-id/1) to see it in action.
+
+### Prerequisites
+
+Run the requried backend services using the supplied docker-compose config. Before starting you must add the following line to your `/etc/hosts` file to allow the authentication service to function:
+
+```
+127.0.0.1 oauth
+```
 
 ### Using nvm (optional)
 If you work across multiple Node.js projects there's a good chance they require different Node.js and npm versions.

--- a/common/config.js
+++ b/common/config.js
@@ -16,8 +16,8 @@ module.exports = {
   sessionSecret: get('SESSION_SECRET', 'app-insecure-default-session', { requireInProduction: true }),
   apis: {
     oauth2: {
-      url: get('NOMIS_AUTH_URL', 'http://localhost:9090/auth', true),
-      externalUrl: get('NOMIS_AUTH_EXTERNAL_URL', get('NOMIS_AUTH_URL', 'http://localhost:9090/auth'), true),
+      url: get('NOMIS_AUTH_URL', 'http://oauth:9090/auth', true),
+      externalUrl: get('NOMIS_AUTH_EXTERNAL_URL', get('NOMIS_AUTH_URL', 'http://oauth:9090/auth'), true),
       timeout: {
         response: get('AUTH_ENDPOINT_TIMEOUT_RESPONSE', 10000, true),
         deadline: get('AUTH_ENDPOINT_TIMEOUT_DEADLINE', 10000, true),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,11 +20,11 @@ services:
       - hmpps
     container_name: oauth
     ports:
-      - "9090:8080"
+      - "9090:9090"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/auth/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:9090/auth/health"]
     environment:
-      - SERVER_PORT=8080
+      - SERVER_PORT=9090
       - SPRING_PROFILES_ACTIVE=dev
 
   elite2-api:
@@ -54,7 +54,7 @@ services:
     environment:
       - SERVER_PORT=8080
       - SPRING_PROFILES_ACTIVE=dev
-      - OAUTH_ENDPOINT_URL=http://oauth:8080/auth
+      - OAUTH_ENDPOINT_URL=http://oauth:9090/auth
 
   sentence-planning-api:
     image: mojdigitalstudio/sentence-planning-api:latest
@@ -72,7 +72,7 @@ services:
     environment:
       - SERVER_PORT=8080
       - DATABASE_ENDPOINT=postgres:5432
-      - OAUTH_ROOT_URL=http://oauth:8080/auth
+      - OAUTH_ROOT_URL=http://oauth:9090/auth
       - ASSESSMENT_API_URI_ROOT=http://offender-assessment-api:8080
       - SPRING_PROFILES_ACTIVE=disableauthorisation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11463,7 +11463,8 @@
       "dependencies": {
         "acorn": {
           "version": "5.7.3",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
           "dev": true
         },
         "acorn-jsx": {


### PR DESCRIPTION
To get the oauth service working required a couple of steps, but the end result is that the service is available at `oauth:9090` on both your local network and within the docker network. the changes involve:

1. adding a line in your hosts file to map `oauth` -> `localhost`. 
2. changing the port mapping for the auth service from 8080 to 9090 in docker-compose.
3 updating the app config to point to the new endpoint.

Small changes were also made to the readme to ensure the quickstart works for new devs.