### PR TITLE
add CI job to quickly validate helm templates pre-merge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,21 @@ commands:
               --values - \
               --set image.tag="${APP_VERSION}" \
               << parameters.extra-helm-args >>
+  validate_helm_chart:
+    description: 'Validate a helm chart by rendering the templates locally'
+    parameters:
+      env:
+        type: string
+    steps:
+      - run:
+          name: parse << parameters.env >> template
+          command: |
+             helm template helm_deploy/sentence-planning \
+             --values helm_deploy/values-<< parameters.env >>.yaml \
+             --values helm_deploy/secrets-example.yaml > MANIFEST-<< parameters.env >>.yaml
+      - store_artifacts:
+          path: MANIFEST-<< parameters.env >>.yaml
+
 executors:
   deployer:
     docker:
@@ -120,6 +135,19 @@ jobs:
           path: test-results
       - store_artifacts:
           path: test-results/unit-test-reports.html
+
+  validate_helm_charts:
+    executor: deployer
+    steps:
+      - checkout
+      - helm/install-helm-client:
+          version: v3.0.2
+      - validate_helm_chart:
+          env: 'development'
+      - validate_helm_chart:
+          env: 'preprod'
+      - validate_helm_chart:
+          env: 'prod'
 
   build_docker:
     executor: deployer
@@ -203,12 +231,6 @@ jobs:
             export SONAR_USER_HOME="$PROJECT_BASE_DIR/.sonar"
             sonar-scanner "${args[@]}"
 
-  deploy_dry_run:
-    executor: deployer
-    steps:
-      - deploy_to_env:
-          env: 'development'
-          extra-helm-args: '--dry-run --debug'
   deploy_dev:
     executor: deployer
     steps:
@@ -254,9 +276,7 @@ workflows:
       - test:
           requires:
             - build
-      - deploy_dry_run:
-          requires:
-            - build
+      - validate_helm_charts
       - build_docker:
           filters:
             branches:
@@ -265,6 +285,7 @@ workflows:
             - test
       - deploy_dev:
           requires:
+            - validate_helm_charts
             - build_docker
       - request-preprod-approval:
           type: approval

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,8 +285,8 @@ workflows:
             - test
       - deploy_dev:
           requires:
-            - validate_helm_charts
             - build_docker
+            - validate_helm_charts
       - request-preprod-approval:
           type: approval
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,8 +285,8 @@ workflows:
             - test
       - deploy_dev:
           requires:
-            - build_docker
             - validate_helm_charts
+            - build_docker
       - request-preprod-approval:
           type: approval
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,7 +208,7 @@ jobs:
     steps:
       - deploy_to_env:
           env: 'development'
-          extra-helm-args: '--dry-run'
+          extra-helm-args: '--dry-run --debug'
   deploy_dev:
     executor: deployer
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,6 +284,9 @@ workflows:
           requires:
             - test
       - deploy_dev:
+          filters:
+            branches:
+              only: master
           requires:
             - validate_helm_charts
             - build_docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,9 @@ commands:
     parameters:
       env:
         type: string
+      extra-helm-args:
+        type: string
+        default: ''
     steps:
       - setup
       - checkout:
@@ -43,7 +46,8 @@ commands:
               --namespace=${KUBE_ENV_NAMESPACE} \
               --values ~/git/helm_deploy/values-<< parameters.env >>.yaml \
               --values - \
-              --set image.tag="${APP_VERSION}"
+              --set image.tag="${APP_VERSION}" \
+              << parameters.extra-helm-args >>
 executors:
   deployer:
     docker:
@@ -199,6 +203,12 @@ jobs:
             export SONAR_USER_HOME="$PROJECT_BASE_DIR/.sonar"
             sonar-scanner "${args[@]}"
 
+  deploy_dry_run:
+    executor: deployer
+    steps:
+      - deploy_to_env:
+          env: 'dry_run'
+          extra-helm-args: '--dry-run --debug'
   deploy_dev:
     executor: deployer
     steps:
@@ -242,6 +252,9 @@ workflows:
             tags:
               ignore: /.*/
       - test:
+          requires:
+            - build
+      - deploy_dry_run:
           requires:
             - build
       - build_docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,7 +207,7 @@ jobs:
     executor: deployer
     steps:
       - deploy_to_env:
-          env: 'dry_run'
+          env: 'dev'
           extra-helm-args: '--dry-run --debug'
   deploy_dev:
     executor: deployer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,7 +208,7 @@ jobs:
     steps:
       - deploy_to_env:
           env: 'development'
-          extra-helm-args: '--dry-run --debug'
+          extra-helm-args: '--dry-run'
   deploy_dev:
     executor: deployer
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,7 +207,7 @@ jobs:
     executor: deployer
     steps:
       - deploy_to_env:
-          env: 'dev'
+          env: 'development'
           extra-helm-args: '--dry-run --debug'
   deploy_dev:
     executor: deployer

--- a/README.md
+++ b/README.md
@@ -31,6 +31,18 @@ Run the requried backend services using the supplied docker-compose config. Befo
 127.0.0.1 oauth
 ```
 
+### Validating the helm templates
+
+You can validate the helm configuration and template rendering locally using the helm CLI tool:
+
+```bash
+brew install helm
+helm template helm_deploy/sentence-planning --values helm_deploy/values-development.yaml \
+                                            --values helm_deploy/secrets-example.yaml
+```
+
+The output of the above command is the full manifest file for the 'development' context (with the secret keys stubbed using the values in `secrets-example.yaml`).
+
 ### Using nvm (optional)
 If you work across multiple Node.js projects there's a good chance they require different Node.js and npm versions.
 

--- a/helm_deploy/secrets-example.yaml
+++ b/helm_deploy/secrets-example.yaml
@@ -1,5 +1,5 @@
 # This is a YAML-formatted file.
-# 
+#
 # Template for secrets which will be stored in AWS secret manager
 
 secrets:
@@ -10,3 +10,4 @@ secrets:
   KEYCLOAK_CLIENT_ID: some_id
   KEYCLOAK_CLIENT_SECRET: some_guid
   APPINSIGHTS_INSTRUMENTATIONKEY: some_guid
+  SESSION_SECRET: some secret


### PR DESCRIPTION
this PR is motivated by a recent case of a PR being merged but the subsequent deployment from master failing due to a typo in the helm chart.

the job runs `helm template` for all each deployment context, verifying that the templates produce valid manifest files. 